### PR TITLE
Web Service connection issues

### DIFF
--- a/mysql.yaml
+++ b/mysql.yaml
@@ -3,12 +3,12 @@ kind: Service
 metadata:
   name: osticket-mysql
   labels:
-    app: osticket
+    app: osticket-mysql
 spec:
   ports:
     - port: 3306
   selector:
-    app: osticket
+    app: osticket-mysql
     tier: mysql
   clusterIP: None
 ---
@@ -17,18 +17,18 @@ kind: Deployment
 metadata:
   name: osticket-mysql
   labels:
-    app: osticket
+    app: osticket-mysql
 spec:
   selector:
     matchLabels:
-      app: osticket
+      app: osticket-mysql
       tier: mysql
   strategy:
     type: Recreate
   template:
     metadata:
       labels:
-        app: osticket
+        app: osticket-mysql
         tier: mysql
     spec:
       containers:

--- a/mysql.yaml
+++ b/mysql.yaml
@@ -3,12 +3,12 @@ kind: Service
 metadata:
   name: osticket-mysql
   labels:
-    app: osticket-mysql
+    app: osticket
 spec:
   ports:
     - port: 3306
   selector:
-    app: osticket-mysql
+    app: osticket
     tier: mysql
   clusterIP: None
 ---
@@ -17,18 +17,18 @@ kind: Deployment
 metadata:
   name: osticket-mysql
   labels:
-    app: osticket-mysql
+    app: osticket
 spec:
   selector:
     matchLabels:
-      app: osticket-mysql
+      app: osticket
       tier: mysql
   strategy:
     type: Recreate
   template:
     metadata:
       labels:
-        app: osticket-mysql
+        app: osticket
         tier: mysql
     spec:
       containers:

--- a/osticket.yaml
+++ b/osticket.yaml
@@ -8,7 +8,6 @@ metadata:
     tier: frontend
 spec:
   type: LoadBalancer
-  sessionAffinity: ClientIP
   ports:
   - port: 80
     protocol: TCP

--- a/osticket.yaml
+++ b/osticket.yaml
@@ -8,6 +8,7 @@ metadata:
     tier: frontend
 spec:
   type: LoadBalancer
+  sessionAffinity: ClientIP
   ports:
   - port: 80
     protocol: TCP

--- a/osticket.yaml
+++ b/osticket.yaml
@@ -13,6 +13,7 @@ spec:
     protocol: TCP
   selector:
     app: osticket
+    tier: frontend
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -6,16 +6,9 @@
 # Create local directory in VM which contains the Mysql DB
 sudo mkdir /mysqldata
 sudo chown 999:999 /mysqldata
-sudo cp $(dirname $0)/netfilter /usr/local/bin
-sudo cp $(dirname $0)/netfilter.service /etc/systemd/system
-sudo chmod 755 /usr/local/bin/netfilter
-sudo systemctl daemon-reload
-sudo systemctl enable netfilter
 
 export KUBECONFIG=$HOME/.kube/config
 kubectl apply -f ~/M437/secrets.yaml
 kubectl apply -f ~/M437/mysql.yaml
 kubectl apply -f ~/M437/osticket.yaml
 
-sleep 60
-sudo reboot

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -6,8 +6,16 @@
 # Create local directory in VM which contains the Mysql DB
 sudo mkdir /mysqldata
 sudo chown 999:999 /mysqldata
+sudo cp $(dirname $0)/netfilter /usr/local/bin
+sudo cp $(dirname $0)/netfilter.service /etc/systemd/system
+sudo chmod 755 /usr/local/bin/netfilter
+sudo systemctl daemon-reload
+sudo systemctl enable netfilter
 
 export KUBECONFIG=$HOME/.kube/config
 kubectl apply -f ~/M437/secrets.yaml
 kubectl apply -f ~/M437/mysql.yaml
 kubectl apply -f ~/M437/osticket.yaml
+
+sleep 60
+sudo reboot

--- a/scripts/netfilter
+++ b/scripts/netfilter
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+
+echo "setting conntrack liberal" >/tmp/netfilter.log
+/sbin/modprobe br_netfilter >>/tmp/netfilter.log 2>&1
+/sbin/modprobe nf_nat_ipv4  >>/tmp/netfilter.log 2>&1
+sleep 10
+/sbin/sysctl -w net.netfilter.nf_conntrack_tcp_be_liberal=1 >> /tmp/netfilter.log 2>&1
+if [ $? -ne 0 ] ; then
+  echo "Failure" >>/tmp/netfilter.log
+else
+  echo "Success" >>/tmp/netfilter.log
+fi
+
+echo "Reading conntrack liberal" >>/tmp/netfilter.log
+/sbin/sysctl net.netfilter.nf_conntrack_tcp_be_liberal >> /tmp/netfilter.log 2>&1

--- a/scripts/netfilter.service
+++ b/scripts/netfilter.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Set sysctl net.netfilter.nf_conntrack_tcp_be_liberal to 1
+Wants=network-online.target
+Before=k3s.service
+[Service]
+Type=oneshot
+RemainAfterExit=true
+ExecStart=/usr/local/bin/netfilter
+[Install]
+RequiredBy=k3s.service


### PR DESCRIPTION
Hoi Marcello,
Ich habe glaube ich eine Loesung gefunden wie mit den http connection issues umgegangen werden kann. 
Im mysql.yaml und im osticket.yaml wurden fuer die labels beide male app:osticket verwendet, im Loadbalancer von osticket wurde im selector dann auch auf den label osticket gezeigt, was machmal an den mysql pod weitergeleitet wurde der auch mit diesem label getagged war. -> ich habe die labels im mysql.yaml auf osticket-mysql umbenannt.
Jetzt scheint es zu funktionieren.
Bitte mergen...
Gruss Armin